### PR TITLE
refactor: update system scripts

### DIFF
--- a/c/ckb_consts.h
+++ b/c/ckb_consts.h
@@ -6,6 +6,9 @@
 #define SYS_ckb_load_cell 2053
 #define SYS_ckb_load_cell_by_field 2054
 #define SYS_ckb_load_input_by_field 2055
+#define SYS_ckb_load_header 2056
+#define SYS_ckb_load_tx_hash 2057
+#define SYS_ckb_load_script_hash 2058
 #define SYS_ckb_debug 2177
 
 #define CKB_SUCCESS 0
@@ -23,7 +26,7 @@
 #define CKB_CELL_FIELD_TYPE 4
 #define CKB_CELL_FIELD_TYPE_HASH 5
 
-#define CKB_INPUT_FIELD_UNLOCK 0
+#define CKB_INPUT_FIELD_ARGS 0
 #define CKB_INPUT_FIELD_OUT_POINT 1
 
 #endif  /* CKB_CONSTS_H_ */

--- a/c/ckb_syscalls.h
+++ b/c/ckb_syscalls.h
@@ -53,6 +53,22 @@ int ckb_load_input_by_field(void* addr, volatile uint64_t* len, size_t offset,
   return syscall(SYS_ckb_load_input_by_field, addr, len, offset, index, source, field);
 }
 
+int ckb_load_header(void* addr, volatile uint64_t* len, size_t offset,
+                    size_t index, size_t source)
+{
+  return syscall(SYS_ckb_load_header, addr, len, offset, index, source, 0);
+}
+
+int ckb_load_tx_hash(void* addr, volatile uint64_t* len, size_t offset)
+{
+  return syscall(SYS_ckb_load_tx_hash, addr, len, offset, 0, 0, 0);
+}
+
+int ckb_load_script_hash(void* addr, volatile uint64_t* len, size_t offset)
+{
+  return syscall(SYS_ckb_load_script_hash, addr, len, offset, 0, 0, 0);
+}
+
 int ckb_debug(const char* s)
 {
   return syscall(SYS_ckb_debug, s, 0, 0, 0, 0, 0);

--- a/c/secp256k1_blake160.h
+++ b/c/secp256k1_blake160.h
@@ -183,7 +183,8 @@ void update_out_point(blake2b_state *ctx, ns(OutPoint_table_t) outpoint)
 
 int verify_sighash_all(const unsigned char* binary_pubkey_hash,
                        const unsigned char* binary_pubkey,
-                       const unsigned char* binary_signature)
+                       const unsigned char* binary_signature,
+                       size_t signature_size)
 {
   unsigned char hash[BLAKE2B_BLOCK_SIZE];
   int ret;
@@ -210,7 +211,7 @@ int verify_sighash_all(const unsigned char* binary_pubkey_hash,
   }
 
   secp256k1_ecdsa_signature signature;
-  ret = secp256k1_ecdsa_signature_parse_compact(&context, &signature, binary_signature);
+  ret = secp256k1_ecdsa_signature_parse_der(&context, &signature, binary_signature, signature_size);
   if (ret == 0) {
     return ERROR_SECP_PARSE_SIGNATURE;
   }

--- a/c/secp256k1_blake160_sighash_all.c
+++ b/c/secp256k1_blake160_sighash_all.c
@@ -5,16 +5,19 @@
  * 0. program name
  * 1. pubkey blake160 hash, blake2b hash of pubkey first 20 bytes, used to shield the real
  * pubkey in lock script.
- * 
+ *
  * Witness:
  * 2. pubkey, real pubkey used to identify token owner
  * 3. signature, signature used to present ownership
+ * 4. signature size
  */
 int main(int argc, char* argv[])
 {
-  if (argc != 4) {
+  uint64_t length = 0;
+  if (argc != 5) {
     return ERROR_WRONG_NUMBER_OF_ARGUMENTS;
   }
 
-  return verify_sighash_all(argv[1], argv[2], argv[3]);
+  length = *((uint64_t *) argv[4]);
+  return verify_sighash_all(argv[1], argv[2], argv[3], length);
 }


### PR DESCRIPTION
This refactor contains the following changes:
* Change sighash all script to use load_tx_hash
* Update bitcoin lock with latest load_script_hash syscall changes
* Update the ABI so we are using binary directly in argv, not hex strings.

Hold for SDK changes.