### PR TITLE
refactor: Adjust build script to allow multiple binaries

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,53 +8,58 @@ use std::{
     path::Path,
 };
 
-const SECP_PATH: &str = "specs/cells/secp256k1_blake160_sighash_all";
+const PATH_PREFIX: &str = "specs/cells/";
 const BUF_SIZE: usize = 8 * 1024;
 const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 
+const BINARIES: &[(&str, &str)] = &[
+    (
+        "secp256k1_blake160_sighash_all",
+        "94334bdda40b69bae067d84937aa6bbccf8acd0df6626d4b9ac70d4612a11933",
+    ),
+];
+
 fn main() {
     let mut bundled = includedir_codegen::start("BUNDLED_CELL");
-    let mut buf = [0u8; BUF_SIZE];
-
-    bundled
-        .add_file(SECP_PATH, Compression::Gzip)
-        .expect("add files to resource bundle");
-
-    // build hash
-    let mut blake2b = new_blake2b();
-    let mut fd = File::open(SECP_PATH).expect("open file");
-    loop {
-        let read_bytes = fd.read(&mut buf).expect("read file");
-        if read_bytes > 0 {
-            blake2b.update(&buf[..read_bytes]);
-        } else {
-            break;
-        }
-    }
-
-    let mut hash = [0u8; 32];
-    blake2b.finalize(&mut hash);
-
-    assert_eq!(
-        "94334bdda40b69bae067d84937aa6bbccf8acd0df6626d4b9ac70d4612a11933",
-        &faster_hex::hex_string(&hash).unwrap()
-    );
-
-    bundled.build("bundled.rs").expect("build resource bundle");
 
     let out_path = Path::new(&env::var("OUT_DIR").unwrap()).join("code_hashes.rs");
     let mut out_file = BufWriter::new(File::create(&out_path).expect("create code_hashes.rs"));
 
-    write!(
-        &mut out_file,
-        "pub const {}: [u8; 32] = {:?};",
-        format!(
-            "CODE_HASH_{}",
-            "secp256k1_blake160_sighash_all".to_uppercase()
-        ),
-        hash
-    )
-    .expect("write to code_hashes.rs");
+    for (name, expected_hash) in BINARIES {
+        let path = format!("{}{}", PATH_PREFIX, name);
+
+        let mut buf = [0u8; BUF_SIZE];
+        bundled
+            .add_file(&path, Compression::Gzip)
+            .expect("add files to resource bundle");
+
+        // build hash
+        let mut blake2b = new_blake2b();
+        let mut fd = File::open(&path).expect("open file");
+        loop {
+            let read_bytes = fd.read(&mut buf).expect("read file");
+            if read_bytes > 0 {
+                blake2b.update(&buf[..read_bytes]);
+            } else {
+                break;
+            }
+        }
+
+        let mut hash = [0u8; 32];
+        blake2b.finalize(&mut hash);
+
+        assert_eq!(expected_hash, &faster_hex::hex_string(&hash).unwrap());
+
+        write!(
+            &mut out_file,
+            "pub const {}: [u8; 32] = {:?};\n",
+            format!("CODE_HASH_{}", name.to_uppercase()),
+            hash
+        )
+        .expect("write to code_hashes.rs");
+    }
+
+    bundled.build("bundled.rs").expect("build resource bundle");
 }
 
 pub fn new_blake2b() -> Blake2b {


### PR DESCRIPTION
This serves as a preparation for adding NervosDAO as another system script