### PR TITLE
fix: Check loaded witness length and return error early

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -14,7 +14,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 
 const BINARIES: &[(&str, &str)] = &[(
     "secp256k1_blake160_sighash_all",
-    "94334bdda40b69bae067d84937aa6bbccf8acd0df6626d4b9ac70d4612a11933",
+    "1435f069749e0b09a194b1d902a5e0c5f69554de9083d311addc7b3490b8ecd1",
 )];
 
 fn main() {

--- a/c/secp256k1_blake160_sighash_all.c
+++ b/c/secp256k1_blake160_sighash_all.c
@@ -16,6 +16,7 @@
 #define ERROR_SECP_SERIALIZE_PUBKEY -9
 #define ERROR_BUFFER_NOT_ENOUGH -10
 #define ERROR_ENCODING -11
+#define ERROR_WITNESS_TOO_LONG -12
 
 #define BLAKE2B_BLOCK_SIZE 32
 #define BLAKE160_SIZE 20
@@ -126,6 +127,9 @@ int main(int argc, char* argv[])
     ret = ckb_load_witness(witness, &len, 0, index, CKB_SOURCE_GROUP_INPUT);
     if (ret != CKB_SUCCESS) {
       return ERROR_SYSCALL;
+    }
+    if (len > WITNESS_SIZE) {
+      return ERROR_WITNESS_TOO_LONG;
     }
 
     if (!(witness_table = ns(Witness_as_root(witness)))) {


### PR DESCRIPTION
Fixes #22 