### PR TITLE
chore: bump to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "ckb-core 0.15.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=1d944e26a16039a1647dc30e5f9b36561203bd68)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-system-scripts"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
### Features

* #20: Cargo publish (@doitian)

    - Remove cells from repo
    - Build cells and publish crate in CI


### Bug Fixes

* #23: Check loaded witness length and return error early (@xxuejie)

    Fixes #22