### PR TITLE
fix: Method typo in lock script

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "secp256k1_blake160_sighash_all",
-        "54811ce986d5c3e57eaafab22cdd080e32209e39590e204a99b32935f835a13c",
+        "a76801d09a0eabbfa545f1577084b6f3bafb0b6250e7f5c89efcfd4e3499fb55",
     ),
     (
         "dao",

--- a/c/secp256k1_blake160_sighash_all.c
+++ b/c/secp256k1_blake160_sighash_all.c
@@ -113,7 +113,7 @@ int main(int argc, char* argv[])
      * size of 8 bytes, which is both predictable, and also provides minimal
      * cycle consumption.
      */
-    ret = ckb_load_cell_by_field(NULL, &len, 0, index, CKB_SOURCE_GROUP_INPUT,
+    ret = ckb_load_input_by_field(NULL, &len, 0, index, CKB_SOURCE_GROUP_INPUT,
                                  CKB_INPUT_FIELD_SINCE);
     if (ret == CKB_INDEX_OUT_OF_BOUND) {
       return 0;


### PR DESCRIPTION
Note: the previous one actually works since the 2 syscalls have the
same behavior. It's just that fixed version more aligns with the
intended logic and comments