### PR TITLE
feat: add chain_root on block header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,9 +163,9 @@ dependencies = [
 [[package]]
 name = "ckb-crypto"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -176,27 +176,27 @@ dependencies = [
 [[package]]
 name = "ckb-dao-utils"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-fixed-hash"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-fixed-hash-hack 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-fixed-hash-hack 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-fixed-hash-core"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -206,9 +206,9 @@ dependencies = [
 [[package]]
 name = "ckb-fixed-hash-hack"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "ckb-hash"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "ckb-logger"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -243,19 +243,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-merkle-mountain-range"
+version = "0.20.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-occupied-capacity"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-occupied-capacity-macros 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-occupied-capacity-macros 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-core"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -264,9 +272,9 @@ dependencies = [
 [[package]]
 name = "ckb-occupied-capacity-macros"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,13 +283,13 @@ dependencies = [
 [[package]]
 name = "ckb-script"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-logger 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-script-data-loader 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-logger 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-script-data-loader 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -291,22 +299,22 @@ dependencies = [
 [[package]]
 name = "ckb-script-data-loader"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
- "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
 ]
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.3.2-alpha.1+refactor-schema"
+version = "0.3.2-alpha.4+chain-root"
 dependencies = [
  "blake2b-rs 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-crypto 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-dao-utils 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-script 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-crypto 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-dao-utils 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-script 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -321,13 +329,14 @@ dependencies = [
 [[package]]
 name = "ckb-types"
 version = "0.20.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d#3d226c5dafd691710c1854547244824fecfb60f0"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17#87a37d17f48243978f91d30face6a6eee485138e"
 dependencies = [
  "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
- "ckb-occupied-capacity 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)",
+ "ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-merkle-mountain-range 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
+ "ckb-occupied-capacity 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2086,19 +2095,20 @@ dependencies = [
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
-"checksum ckb-crypto 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-dao-utils 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-fixed-hash-hack 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-logger 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-occupied-capacity 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-occupied-capacity-macros 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-script 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-script-data-loader 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
-"checksum ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=3d226c5d)" = "<none>"
+"checksum ckb-crypto 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-dao-utils 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-fixed-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-fixed-hash-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-fixed-hash-hack 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-hash 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-logger 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-merkle-mountain-range 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-occupied-capacity 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-occupied-capacity-core 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-occupied-capacity-macros 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-script 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-script-data-loader 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
+"checksum ckb-types 0.20.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=87a37d17)" = "<none>"
 "checksum ckb-vm 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f089b008f8fa02e44b409b2c24ee9a9f65216f24cebeccc598162d3a44a675ad"
 "checksum ckb-vm-definitions 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd297669e4783ddca472fa00e7d2117b2d1dcb67cca814d5dd222852b8dba088"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-system-scripts"
-version = "0.3.2-alpha.2+refactor-schema"
+version = "0.3.2-alpha.4+chain-root"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"
@@ -20,11 +20,11 @@ faster-hex = "0.3"
 
 [dev-dependencies]
 byteorder = "1.3.1"
-ckb-types = { git = "https://github.com/nervosnetwork/ckb.git", rev = "3d226c5d" }
-ckb-script = { git = "https://github.com/nervosnetwork/ckb.git", rev = "3d226c5d" }
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb.git", rev = "3d226c5d" }
-ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb.git", rev = "3d226c5d" }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb.git", rev = "3d226c5d" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb.git", rev = "87a37d17" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb.git", rev = "87a37d17" }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb.git", rev = "87a37d17" }
+ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb.git", rev = "87a37d17" }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb.git", rev = "87a37d17" }
 rand = "0.6.5"
 lazy_static = "1.3.0"
 ripemd160 = "0.8.0"

--- a/build.rs
+++ b/build.rs
@@ -23,7 +23,7 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "dao",
-        "64dce4af48b54197a188b2deb6c3ad99347dd680ffe0d0c85061a92012d7665b",
+        "b25d44d0608f856f13c020472e275db96ce2d24021baedb92a2c46883426e209",
     ),
     (
         "secp256k1_ripemd160_sha256_sighash_all",

--- a/c/ckb.mol
+++ b/c/ckb.mol
@@ -1,4 +1,4 @@
-// Copy from ckb-types (#3d226c5d).
+// Copy from ckb-types (#87a37d17).
 
 /* Basic Types */
 
@@ -95,6 +95,7 @@ struct RawHeader {
     difficulty:             Byte32,
     uncles_hash:            Byte32,
     dao:                    Byte32,
+    chain_root:             Byte32,
 }
 
 struct Header {
@@ -112,6 +113,13 @@ table Block {
     uncles:                 UncleBlockVec,
     transactions:           TransactionVec,
     proposals:              ProposalShortIdVec,
+}
+
+/* Types for Chain root MMR */
+
+struct HeaderDigest {
+    hash:               Byte32,
+    total_difficulty:   Byte32,
 }
 
 /* Types for Storage */


### PR DESCRIPTION
This PR update `ckb.mol` to add a new field `chain_root` on block header

wait for https://github.com/nervosnetwork/ckb/pull/1505 https://github.com/nervosnetwork/ckb/pull/1518

Please merge this after the two PR above.