### PR TITLE
feat: remove restrict of witnesses length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -394,7 +394,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-system-scripts"
-version = "0.4.0-alpha.12+nonstrict-witnesses-length"
+version = "0.4.0-alpha.13+nonstrict-witnesses-length2"
 dependencies = [
  "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,11 +161,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-crypto"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+name = "ckb-chain-spec"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-fixed-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-crypto 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-dao-utils 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-jsonrpc-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-pow 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-rational 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-resource 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ckb-crypto"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
+dependencies = [
+ "ckb-fixed-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -175,40 +195,40 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-error 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-types 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "enum-display-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-error"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-occupied-capacity 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-occupied-capacity 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "enum-display-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-fixed-hash-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-fixed-hash-hack 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-fixed-hash-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-fixed-hash-hack 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -217,10 +237,10 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-hack"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-fixed-hash-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-fixed-hash-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -229,16 +249,29 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "ckb-jsonrpc-types"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
+dependencies = [
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-logger"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "backtrace 0.3.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -256,18 +289,18 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-occupied-capacity-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-occupied-capacity-macros 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-occupied-capacity-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-occupied-capacity-macros 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -275,35 +308,64 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-occupied-capacity-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-occupied-capacity-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "proc-macro-hack 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "ckb-pow"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "eaglesong 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-rational"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
+name = "ckb-resource"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
+dependencies = [
+ "ckb-system-scripts 0.4.0-alpha.10+witness-args (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-script"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-error 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-logger 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-script-data-loader 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-types 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-vm 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-chain-spec 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-logger 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-script-data-loader 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "faster-hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -312,10 +374,10 @@ dependencies = [
 
 [[package]]
 name = "ckb-script-data-loader"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
- "ckb-types 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
 ]
 
 [[package]]
@@ -324,12 +386,12 @@ version = "0.4.0-alpha.10+witness-args"
 dependencies = [
  "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-crypto 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-dao-utils 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-error 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-script 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-types 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-crypto 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-dao-utils 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-script 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -342,33 +404,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-system-scripts"
+version = "0.4.0-alpha.10+witness-args"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ckb-types"
-version = "0.23.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb.git?rev=5360805#5360805be557a8b5b05c236b8e7b9fa9c989ecbb"
+version = "0.24.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5#d75e4c56ffa40e17fd2fe477da3f98c5578edcd1"
 dependencies = [
  "bit-vec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-error 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-fixed-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-occupied-capacity 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
- "ckb-rational 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)",
+ "ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-fixed-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-occupied-capacity 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
+ "ckb-rational 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)",
  "crossbeam-channel 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "merkle-cbt 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "molecule 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "numext-fixed-uint 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ckb-vm"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)",
- "ckb-vm-definitions 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "goblin 0.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -376,7 +451,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-vm-definitions"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -494,6 +569,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -504,6 +592,11 @@ dependencies = [
 [[package]]
 name = "dtoa"
 version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "eaglesong"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -856,6 +949,18 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "jsonrpc-core"
+version = "10.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "kernel32-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,7 +1103,7 @@ dependencies = [
 
 [[package]]
 name = "molecule"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1933,6 +2038,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.98 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2153,23 +2266,28 @@ dependencies = [
 "checksum cc 1.0.38 (registry+https://github.com/rust-lang/crates.io-index)" = "ce400c638d48ee0e9ab75aef7997609ec57367ccfe1463f21bf53c3eca67bf46"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "77d81f58b7301084de3b958691458a53c3f7e0b1d702f77e550b6a88e3a88abe"
-"checksum ckb-crypto 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-dao-utils 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-error 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-fixed-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-fixed-hash-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-fixed-hash-hack 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-hash 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-logger 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-occupied-capacity 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-occupied-capacity-core 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-occupied-capacity-macros 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-rational 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-script 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-script-data-loader 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-types 0.23.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=5360805)" = "<none>"
-"checksum ckb-vm 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b95ed9373dd7af32ec8c7d450b5fd5d1b4c7f1ce49ba1bf0f59956b00d588224"
-"checksum ckb-vm-definitions 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)" = "55c0c2211e4174e54d5e73a353cd8834c5cd2395dfaeb6b88f05ab435b5a761b"
+"checksum ckb-chain-spec 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-crypto 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-dao-utils 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-error 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-fixed-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-fixed-hash-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-fixed-hash-hack 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-hash 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-jsonrpc-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-logger 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-occupied-capacity 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-occupied-capacity-core 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-occupied-capacity-macros 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-pow 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-rational 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-resource 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-script 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-script-data-loader 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-system-scripts 0.4.0-alpha.10+witness-args (registry+https://github.com/rust-lang/crates.io-index)" = "387db7de0020cbc3c20801cdba8ed1ae19acc9fd89ffb0b02c34862c71cda2db"
+"checksum ckb-types 0.24.0-pre (git+https://github.com/nervosnetwork/ckb.git?rev=d75e4c5)" = "<none>"
+"checksum ckb-vm 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "410eca836e677ea70f73358b53220c284836c3cbb3ecf9ee531606d926881f59"
+"checksum ckb-vm-definitions 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "201ab0ce4cf5644b3f0cacc9d772011f66c132d5e62ab35918413d9a6c29e6a7"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum cookie 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "888604f00b3db336d2af898ec3c1d5d0ddf5e6d462220f2ededc33a87ac4bbd5"
 "checksum cookie_store 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "46750b3f362965f197996c4448e4a0935e791bf7d6631bfce9ee0af3d24c919c"
@@ -2182,8 +2300,10 @@ dependencies = [
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum debugid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "088c9627adec1e494ff9dea77377f1e69893023d631254a0ec68b16ee20be3e9"
+"checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dtoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ea57b42383d091c85abcc2706240b94ab2a8fa1fc81c10ff23c4de06e2a90b5e"
+"checksum eaglesong 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8d978bd5d343e8ab9b5c0fc8d93ff9c602fdc96616ffff9c05ac7a155419b824"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum encoding_rs 0.8.17 (registry+https://github.com/rust-lang/crates.io-index)" = "4155785c79f2f6701f185eb2e6b4caf0555ec03477cb4c70db67b465311620ed"
 "checksum enum-display-derive 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53f76eb63c4bfc6fce5000f106254701b741fc9a65ee08445fde0ff39e583f1c"
@@ -2224,6 +2344,7 @@ dependencies = [
 "checksum indexmap 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4d6d89e0948bf10c08b9ecc8ac5b83f07f857ebe2c0cbe38de15b4e4f510356"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
+"checksum jsonrpc-core 10.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dc15eef5f8b6bef5ac5f7440a957ff95d036e2f98706947741bfc93d1976db4c"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc5729f27f159ddd61f4df6228e827e86643d4d3e7c32183cb30a1c08f604a14"
 "checksum libc 0.2.60 (registry+https://github.com/rust-lang/crates.io-index)" = "d44e80633f007889c7eff624b709ab43c92d708caad982295768a7b13ca3b5eb"
@@ -2241,7 +2362,7 @@ dependencies = [
 "checksum miniz_oxide_c_api 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6c675792957b0d19933816c4e1d56663c341dd9bfa31cb2140ff2267c1d8ecf4"
 "checksum mio 0.6.19 (registry+https://github.com/rust-lang/crates.io-index)" = "83f51996a3ed004ef184e16818edc51fadffe8e7ca68be67f9dee67d84d0ff23"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
-"checksum molecule 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "76407f4e58d5e747dbfd136b6f191923530731bdfa4b18b990fa61c0620bfaf9"
+"checksum molecule 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba0619bb93e13e12d7e04ab7a1e57f2331f37fa7412f64cf8ef49d1603e0a82a"
 "checksum native-tls 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b2df1a4c22fd44a62147fd8f13dd0f95c9d8ca7b2610299b2a2f9cf8964274e"
 "checksum net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)" = "42550d9fb7b6684a6d404d9fa7250c2eb2646df731d1c06afc06dcee9e1bcf88"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
@@ -2341,6 +2462,7 @@ dependencies = [
 "checksum tokio-tcp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1d14b10654be682ac43efee27401d792507e30fd8d26389e1da3b185de2e4119"
 "checksum tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "90ca01319dea1e376a001e8dc192d42ebde6dd532532a5bad988ac37db365b19"
 "checksum tokio-timer 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "f2106812d500ed25a4f38235b9cae8f78a09edf43203e16e59c3b769a342a60e"
+"checksum toml 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c7aabe75941d914b72bf3e5d3932ed92ce0664d49d8432305a8b547c37227724"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum try_from 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "283d3b89e1368717881a9d51dad843cc435380d8109c9e47d38780a324698d8b"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,18 @@ dependencies = [
 [[package]]
 name = "ckb-system-scripts"
 version = "0.4.0-alpha.10+witness-args"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ckb-system-scripts"
+version = "0.4.0-alpha.12+nonstrict-witnesses-length"
 dependencies = [
  "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -401,18 +413,6 @@ dependencies = [
  "ripemd160 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.15.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "ckb-system-scripts"
-version = "0.4.0-alpha.10+witness-args"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "blake2b-rs 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "faster-hex 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "includedir 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "includedir_codegen 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "phf 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-system-scripts"
-version = "0.4.0-alpha.10+witness-args"
+version = "0.4.0-alpha.12+nonstrict-witnesses-length"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,12 @@ faster-hex = "0.3"
 
 [dev-dependencies]
 byteorder = "1.3.1"
-ckb-types = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
-ckb-script = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
-ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
-ckb-error = { git = "https://github.com/nervosnetwork/ckb.git", rev = "5360805" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
+ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
+ckb-error = { git = "https://github.com/nervosnetwork/ckb.git", rev = "d75e4c5" }
 rand = "0.6.5"
 lazy_static = "1.3.0"
 ripemd160 = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-system-scripts"
-version = "0.4.0-alpha.12+nonstrict-witnesses-length"
+version = "0.4.0-alpha.13+nonstrict-witnesses-length2"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MOLC := moleculec
 MOLC_VERSION := 0.4.1
 PROTOCOL_HEADER := c/protocol.h
 PROTOCOL_SCHEMA := c/blockchain.mol
-PROTOCOL_VERSION := 3615b65050173747c4a285b068bccaa44a3f0deb
+PROTOCOL_VERSION := d75e4c56ffa40e17fd2fe477da3f98c5578edcd1
 PROTOCOL_URL := https://raw.githubusercontent.com/nervosnetwork/ckb/${PROTOCOL_VERSION}/util/types/schemas/blockchain.mol
 
 # docker pull nervos/ckb-riscv-gnu-toolchain:bionic-20190702

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "secp256k1_blake160_sighash_all",
-        "8feb52e0bfb0df4bd919e999b35b97b1763b8705e20bc728154009811bad0aba",
+        "67dd0663fd5efcb19f709515505929c37e0567ad9e2e6327a82957a401a6b35f",
     ),
     (
         "secp256k1_data",
@@ -27,7 +27,7 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "secp256k1_ripemd160_sha256_sighash_all",
-        "165bf87936ae07c9084319a1b76677ded0042a1df3abd3fade650c37def71a48",
+        "7b38f12eb80e3f8002c74dec33b4048742d9b4aa9c49182c98c27372ab88e702",
     ),
 ];
 

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "secp256k1_blake160_sighash_all",
-        "b6474b198fd8bd11b36f8946bde8a93ff75737c683bbab28486ec40b4fd96eac",
+        "8feb52e0bfb0df4bd919e999b35b97b1763b8705e20bc728154009811bad0aba",
     ),
     (
         "secp256k1_data",
@@ -23,11 +23,11 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "dao",
-        "6ad9e0a2474a1da704fee21393d6040cf8ef4ebdf23ad86b62dc3a62a9cbc1da",
+        "c8883b9adda673ab6af47dc7be4029e5ca72d915f7258fdeafe4097dd9125399",
     ),
     (
         "secp256k1_ripemd160_sha256_sighash_all",
-        "bcffc5a4858bdc799308822c583206abde0aa871afd261799ce01448dd8a51e1",
+        "165bf87936ae07c9084319a1b76677ded0042a1df3abd3fade650c37def71a48",
     ),
 ];
 

--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,7 @@ const CKB_HASH_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 const BINARIES: &[(&str, &str)] = &[
     (
         "secp256k1_blake160_sighash_all",
-        "67dd0663fd5efcb19f709515505929c37e0567ad9e2e6327a82957a401a6b35f",
+        "0b39d5a75a0605387d7b50592c24d33e152581e7357058fa95f3a640b0d9bf8b",
     ),
     (
         "secp256k1_data",
@@ -23,11 +23,11 @@ const BINARIES: &[(&str, &str)] = &[
     ),
     (
         "dao",
-        "c8883b9adda673ab6af47dc7be4029e5ca72d915f7258fdeafe4097dd9125399",
+        "007c21b2593e645f390b068a14f6941aa3382ec88edf594e8bffbbb4bbf444f5",
     ),
     (
         "secp256k1_ripemd160_sha256_sighash_all",
-        "7b38f12eb80e3f8002c74dec33b4048742d9b4aa9c49182c98c27372ab88e702",
+        "a9dc4428654d841c6bc6b38cbbd1152f083e98986ef093accdf1dd5ee99a7104",
     ),
 ];
 

--- a/c/ckb_syscalls.h
+++ b/c/ckb_syscalls.h
@@ -145,4 +145,20 @@ int ckb_debug(const char* s) {
   return syscall(SYS_ckb_debug, s, 0, 0, 0, 0, 0);
 }
 
+/* load the actual witness for the current type verify group.
+   use this instead of ckb_load_witness if type contract needs args to verify input/output.
+ */
+int load_actual_type_witness(uint8_t *buf, uint64_t *len, size_t index,
+                             size_t *type_source) {
+  *type_source = CKB_SOURCE_GROUP_INPUT;
+  uint64_t tmp_len = 0;
+  if (ckb_load_cell_by_field(NULL, &tmp_len, 0, 0, CKB_SOURCE_GROUP_INPUT,
+                             CKB_CELL_FIELD_CAPACITY) ==
+      CKB_INDEX_OUT_OF_BOUND) {
+    *type_source = CKB_SOURCE_GROUP_OUTPUT;
+  }
+
+  return ckb_load_witness(buf, len, 0, index, *type_source);
+}
+
 #endif /* CKB_SYSCALLS_H_ */

--- a/c/common.h
+++ b/c/common.h
@@ -11,14 +11,12 @@
 #define ERROR_SECP_SERIALIZE_PUBKEY -15
 #define ERROR_SCRIPT_TOO_LONG -21
 #define ERROR_WITNESS_SIZE -22
-#define ERROR_INVALID_WITNESSES_COUNT -23
 #define ERROR_PUBKEY_BLAKE160_HASH -31
 #define ERROR_PUBKEY_RIPEMD160_HASH -32
 
-/* make sure that witnesses and inputs have the same length */
-int check_witnesses_len() {
+/* calculate inputs length */
+int calculate_inputs_len() {
   uint64_t len = 0;
-  uint8_t tmp[0];
   /* lower bound, at least tx has one input */
   int lo = 0;
   /* higher bound */
@@ -26,7 +24,7 @@ int check_witnesses_len() {
   int ret;
   /* try to load input until failing to increase lo and hi */
   while (1) {
-    ret = ckb_load_input_by_field(tmp, &len, 0, hi, CKB_SOURCE_INPUT,
+    ret = ckb_load_input_by_field(NULL, &len, 0, hi, CKB_SOURCE_INPUT,
                                   CKB_INPUT_FIELD_SINCE);
     if (ret == CKB_SUCCESS) {
       lo = hi;
@@ -41,7 +39,7 @@ int check_witnesses_len() {
   int i;
   while (lo + 1 != hi) {
     i = (lo + hi) / 2;
-    ret = ckb_load_input_by_field(tmp, &len, 0, i, CKB_SOURCE_INPUT,
+    ret = ckb_load_input_by_field(NULL, &len, 0, i, CKB_SOURCE_INPUT,
                                   CKB_INPUT_FIELD_SINCE);
     if (ret == CKB_SUCCESS) {
       lo = i;
@@ -49,14 +47,6 @@ int check_witnesses_len() {
       hi = i;
     }
   }
-  /* witnesses and inputs must have the same length */
-  ret = ckb_load_witness(tmp, &len, 0, hi, CKB_SOURCE_INPUT);
-  if (ret == CKB_SUCCESS) {
-    return ERROR_INVALID_WITNESSES_COUNT;
-  }
-  ret = ckb_load_witness(tmp, &len, 0, lo, CKB_SOURCE_INPUT);
-  if (ret != CKB_SUCCESS) {
-    return ERROR_INVALID_WITNESSES_COUNT;
-  }
-  return CKB_SUCCESS;
+  /* now lo is last input index and hi is length of inputs */
+  return hi;
 }

--- a/c/dao.c
+++ b/c/dao.c
@@ -117,7 +117,7 @@ static int extract_withdraw_header_index(size_t input_index, size_t *index) {
     return ERROR_ENCODING;
   }
   /* Load type args */
-  mol_seg_t type_seg = MolReader_WitnessArgs_get_type_(&witness_seg);
+  mol_seg_t type_seg = MolReader_WitnessArgs_get_input_type(&witness_seg);
 
   mol_seg_t type_bytes_seg = MolReader_Bytes_raw_bytes(&type_seg);
   if (type_bytes_seg.size != 8) {

--- a/c/dao.c
+++ b/c/dao.c
@@ -119,6 +119,10 @@ static int extract_withdraw_header_index(size_t input_index, size_t *index) {
   /* Load type args */
   mol_seg_t type_seg = MolReader_WitnessArgs_get_input_type(&witness_seg);
 
+  if (MolReader_BytesOpt_is_none(&type_seg)) {
+    return ERROR_ENCODING;
+  }
+
   mol_seg_t type_bytes_seg = MolReader_Bytes_raw_bytes(&type_seg);
   if (type_bytes_seg.size != 8) {
     return ERROR_ENCODING;

--- a/c/secp256k1_blake160_sighash_all.c
+++ b/c/secp256k1_blake160_sighash_all.c
@@ -26,6 +26,9 @@ int extract_witness_lock(uint8_t *witness, uint64_t len,
   }
   mol_seg_t lock_seg = MolReader_WitnessArgs_get_lock(&witness_seg);
 
+  if (MolReader_BytesOpt_is_none(&lock_seg)) {
+    return ERROR_ENCODING;
+  }
   *lock_bytes_seg = MolReader_Bytes_raw_bytes(&lock_seg);
   return CKB_SUCCESS;
 }
@@ -55,7 +58,7 @@ int main() {
     return ERROR_SCRIPT_TOO_LONG;
   }
   mol_seg_t script_seg;
-  script_seg.ptr = (uint8_t*)script;
+  script_seg.ptr = (uint8_t *)script;
   script_seg.size = len;
 
   if (MolReader_Script_verify(&script_seg, false) != MOL_OK) {

--- a/c/secp256k1_ripemd160_sha256_sighash_all.c
+++ b/c/secp256k1_ripemd160_sha256_sighash_all.c
@@ -61,6 +61,9 @@ int extract_witness_lock(uint8_t *witness, uint64_t len,
   }
   mol_seg_t lock_seg = MolReader_WitnessArgs_get_lock(&witness_seg);
 
+  if (MolReader_BytesOpt_is_none(&lock_seg)) {
+    return ERROR_ENCODING;
+  }
   *lock_bytes_seg = MolReader_Bytes_raw_bytes(&lock_seg);
   return CKB_SUCCESS;
 }

--- a/src/tests/secp256k1_blake160_sighash_all.rs
+++ b/src/tests/secp256k1_blake160_sighash_all.rs
@@ -19,7 +19,6 @@ use rand::{thread_rng, Rng, SeedableRng};
 
 const ERROR_ENCODING: i8 = -2;
 const ERROR_WITNESS_TOO_LONG: i8 = -22;
-const ERROR_INVALID_WITNESSES_COUNT: i8 = -23;
 const ERROR_PUBKEY_BLAKE160_HASH: i8 = -31;
 
 fn gen_tx(dummy: &mut DummyDataLoader, lock_args: Bytes) -> TransactionView {
@@ -396,7 +395,7 @@ fn test_super_long_witness() {
 
 #[test]
 fn test_sighash_all_2_in_2_out_cycles() {
-    const CONSUME_CYCLES: u64 = 3395490;
+    const CONSUME_CYCLES: u64 = 3394584;
 
     let mut data_loader = DummyDataLoader::new();
     let mut generator = Generator::non_crypto_safe_prng(42);
@@ -551,7 +550,7 @@ fn test_sighash_all_witnesses_ambiguity() {
 }
 
 #[test]
-fn test_sighash_all_too_many_witnesses() {
+fn test_sighash_all_cover_extra_witnesses() {
     let mut rng = thread_rng();
     let mut data_loader = DummyDataLoader::new();
     let privkey = Generator::random_privkey();
@@ -564,17 +563,29 @@ fn test_sighash_all_too_many_witnesses() {
         .as_advanced_builder()
         .set_witnesses(vec![
             witness.pack(),
-            Bytes::new().pack(),
             Bytes::from(vec![42]).pack(),
+            Bytes::new().pack(),
         ])
         .build();
     let tx = sign_tx_by_input_group(tx, &privkey, 0, 3);
     assert!(tx.witnesses().len() > tx.inputs().len());
+
+    // change last witness
+    let mut witnesses = Unpack::<Vec<_>>::unpack(&tx.witnesses());
+    let tx = tx
+        .as_advanced_builder()
+        .set_witnesses(vec![
+            witnesses.remove(0).pack(),
+            witnesses.remove(1).pack(),
+            Bytes::from(vec![0]).pack(),
+        ])
+        .build();
+
     let resolved_tx = build_resolved_tx(&data_loader, &tx);
     let verify_result =
         TransactionScriptsVerifier::new(&resolved_tx, &data_loader).verify(60000000);
     assert_error_eq!(
         verify_result.unwrap_err(),
-        ScriptError::ValidationFailure(ERROR_INVALID_WITNESSES_COUNT),
+        ScriptError::ValidationFailure(ERROR_PUBKEY_BLAKE160_HASH),
     );
 }

--- a/src/tests/secp256k1_blake160_sighash_all.rs
+++ b/src/tests/secp256k1_blake160_sighash_all.rs
@@ -396,7 +396,7 @@ fn test_super_long_witness() {
 
 #[test]
 fn test_sighash_all_2_in_2_out_cycles() {
-    const CONSUME_CYCLES: u64 = 3395472;
+    const CONSUME_CYCLES: u64 = 3395490;
 
     let mut data_loader = DummyDataLoader::new();
     let mut generator = Generator::non_crypto_safe_prng(42);

--- a/src/tests/secp256k1_blake160_sighash_all.rs
+++ b/src/tests/secp256k1_blake160_sighash_all.rs
@@ -395,7 +395,7 @@ fn test_super_long_witness() {
 
 #[test]
 fn test_sighash_all_2_in_2_out_cycles() {
-    const CONSUME_CYCLES: u64 = 3394584;
+    const CONSUME_CYCLES: u64 = 3394620;
 
     let mut data_loader = DummyDataLoader::new();
     let mut generator = Generator::non_crypto_safe_prng(42);


### PR DESCRIPTION
* remove restrict of witnesses length
* update WitnessArgs
* a new function `load_actual_type_witness` to demonstrate how to load witness by check current verify group source.