### PR TITLE
feat: Use curl instead of wget to fetch protocol files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ${PROTOCOL_HEADER}: ${PROTOCOL_SCHEMA}
 	${MOLC} --language c --schema-file $< > $@
 
 ${PROTOCOL_SCHEMA}:
-	wget -O $@ ${PROTOCOL_URL}
+	curl -L -o $@ ${PROTOCOL_URL}
 
 install-tools:
 	if [ ! -x "$$(command -v "${MOLC}")" ] \


### PR DESCRIPTION
While the functionality stays the same, curl has 2 points over wget:

* curl is installed by default in more distributions than wget
* curl respects proxy environment variables, while wget requires its
  own config