### PR TITLE
Bump ckb-system-scripts to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,7 +327,7 @@ version = "0.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23d09e2994f8696c6a73e16a44500d012ece93085cf44d4d872b82920b8a4c0"
 dependencies = [
- "ckb-system-scripts 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ckb-system-scripts 0.5.4",
  "ckb-types",
  "includedir",
  "includedir_codegen",
@@ -357,6 +357,19 @@ dependencies = [
 [[package]]
 name = "ckb-system-scripts"
 version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
+dependencies = [
+ "blake2b-rs",
+ "faster-hex",
+ "includedir",
+ "includedir_codegen",
+ "phf",
+]
+
+[[package]]
+name = "ckb-system-scripts"
+version = "0.6.0"
 dependencies = [
  "blake2b-rs",
  "byteorder",
@@ -376,19 +389,6 @@ dependencies = [
  "ripemd160",
  "secp256k1 0.15.5",
  "sha2",
-]
-
-[[package]]
-name = "ckb-system-scripts"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
-dependencies = [
- "blake2b-rs",
- "faster-hex",
- "includedir",
- "includedir_codegen",
- "phf",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-system-scripts"
-version = "0.5.4"
+version = "0.6.0"
 authors = ["Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
This PR want:
1. bump ckb-system-scripts to v0.6.0


Invite @doitian @XuJiandong @xxuejie @zhangsoledad @quake  to review.